### PR TITLE
Fix the value of tls-server-name flag in tutorial

### DIFF
--- a/docs/tutorial/kubernetes-api-server.md
+++ b/docs/tutorial/kubernetes-api-server.md
@@ -169,7 +169,7 @@ apiVersion: v1
 clusters:
 - cluster:
     server: https://k3s.example.com:443
-    tls-server-name: k3s.example.com
+    tls-server-name: kubernetes
 ```
 
 For more details see: [Support TLS Server Name overrides in kubeconfig file #88769](https://github.com/kubernetes/kubernetes/pull/88769)


### PR DESCRIPTION
Signed-off-by: Zespre Schmidt <starbops@zespre.com>

## Description

A quick fix regarding issue #1 

## Motivation and Context

- [x] I have raised an issue to propose this change ([required](https://github.com/inlets/docs.inlets.dev/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
