### PR TITLE
Fix tcp tunnel example in inlets-uplink docs

### DIFF
--- a/docs/uplink/manage-tunnels.md
+++ b/docs/uplink/manage-tunnels.md
@@ -203,7 +203,10 @@ Try it out:
 ```bash
 export PASSWORD="8cb3efe58df984d3ab89bcf4566b31b49b2b79b9"
 
-kubectl run -it -env PGPORT=5432 -env PGPASSWORD=$PASSWORD --rm postgres:latest psql -U postgres -h prod-database.acmeco
+kubectl run -i -t psql \
+  -env PGPORT=5432 \
+  -env PGPASSWORD=$PASSWORD --rm \
+  --image postgres:latest -- psql -U postgres -h prod-database.acmeco
 ```
 
 Try a command such as `CREATE database websites (url TEXT)`, `\dt` or `\l`.


### PR DESCRIPTION
Include the correct 'kubectl run' commands.

Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix the tcp tunnel example for Postgresql in the inlets-uplink docs. Include the correct `kubectl run` commands.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The 'kubectl run'  command used in the example is incorrect.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified commands.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
