### PR TITLE
Add connect to tunnels page in uplink docs

### DIFF
--- a/docs/uplink/connect-to-tunnels.md
+++ b/docs/uplink/connect-to-tunnels.md
@@ -1,0 +1,130 @@
+# Connect to tunnels
+
+The tunnel plugin for the inlets-pro CLI can be used to get connection instructions for a tunnel.
+
+Whether the client needs to be deployed as a systemd service on the customers server or as a Kubernetes service, with the CLI it is easy to generate connection instructions for these different formats by setting the `--format` flag.
+
+Supported formats:
+
+- [CLI command](#get-connection-instructions)
+- [Systemd](#deploy-the-client-as-a-systemd-service) 
+- [Kubernetes YAML Deployment](#deploy-the-client-in-a-kubernetes-cluster)
+
+Make sure you have the latest version of the tunnel command available:
+
+```bash
+inlets-pro plugin get tunnel
+```
+
+## Get connection instructions
+
+Generate the client command for the selected tunnel:
+
+```bash
+$ inlets-pro tunnel connect openfaas \
+    --domain uplink.example.com \
+    --upstream http://127.0.0.1:8080
+
+# Access your HTTP tunnel via: http://openfaas.tunnels:8000
+
+# Access your TCP tunnel via ClusterIP: 
+#  openfaas.tunnels:5432
+
+inlets-pro uplink client \
+  --url=wss://uplink.example.com/tunnels/openfaas \
+  --token=tbAd4HooCKLRicfcaB5tZvG3Qj36pjFSL3Qob6b9DBlgtslmildACjWZUD \
+  --upstream=http://127.0.0.1:8080
+```
+
+Optionally the `--quiet` flag can be set to print the CLI command without the additional info.
+
+## Deploy the client as a systemd service
+
+To generate a systemd service file for the tunnel client command set the `--format` flag to `systemd`. 
+
+```bash
+$ inlets-pro tunnel connect openfaas \
+    --domain uplink.example.com \ 
+    --upstream http://127.0.0.1:8080 \
+    --format systemd
+
+[Unit]
+Description=openfaas inlets client
+After=network.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5
+StartLimitInterval=0
+ExecStart=/usr/local/bin/inlets-pro uplink client --url=wss://uplink.example.com/tunnels/openfaas --token=tbAd4HooCKLRicfcaB5tZvG3Qj36pjFSL3Qob6b9DBlgtslmildACjWZUD --upstream=http://127.0.0.1:8080
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Copy the service file over to the customer's host. Save the unit file as: `/etc/systemd/system/openfaas-tunnel.service`.
+
+Once the file is in place start the service for the first time:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now openfaas-tunnel
+```
+
+Verify the tunnel client is running:
+
+```bash
+systemctl status openfaas-tunnel
+```
+
+You can also check the logs to see if the client connected successfully:
+
+```bash
+journalctl -u openfaas-tunnel
+```
+
+## Deploy the client in a Kubernetes cluster
+
+To generate a YAML deployment for a selected tunnel, set the `--format` flag to `k8s_yaml`. The generated resource can be deployed in the customers cluster.
+
+```bash
+inlets-pro tunnel connect openfaas \
+    --domain uplink.example.com \
+    --upstream http://gateway.openfaas:8080 \
+    --format k8s_yaml
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openfaas-inlets-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openfaas-inlets-client
+  template:
+    metadata:
+      labels:
+        app: openfaas-inlets-client
+    spec:
+      containers:
+      - name: openfaas-inlets-client
+        image: ghcr.io/inlets/inlets-pro:0.9.14
+        imagePullPolicy: IfNotPresent
+        command: ["inlets-pro"]
+        args:
+        - "uplink"
+        - "client"
+        - "--url=wss://uplink.example.com/tunnels/openfaas"
+        - "--token=tbAd4HooCKLRicfcaB5tZvG3Qj36pjFSL3Qob6b9DBlgtslmildACjWZUD"
+        - "--upstream=http://gateway.openfaas:8080"
+```
+
+In this example we create a tunnel to uplink an [OpenFaaS](https://www.openfaas.com/) deployment.
+
+Get the logs for the client and check it connected successfully:
+
+```bash
+kubectl logs deploy/openfaas-inlets-client
+```

--- a/docs/uplink/create-tunnels.md
+++ b/docs/uplink/create-tunnels.md
@@ -347,59 +347,6 @@ kubectl run -i -t psql \
 
 Try a command such as `CREATE database websites (url TEXT)`, `\dt` or `\l`.
 
-## Deploy the client in a Kubernetes cluster
-
-The following resources are meant to be applied in the customers cluster.
-
-1. Create a secret with the token for the customer tunnel.
-
-    ```bash
-    kubectl create secret generic \
-      inlets-token \
-      --from-file token=./token.txt
-    ```
-
-2. Create a deployment for the client.
-  
-    For example the following configuration will deploy the tunnel client and connect to the acmeco tunnel in the inlets uplink control cluster. It will tunnel the customers OpenFaaS gateway service and make it accessible in the control cluster.
-
-    ```yaml
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: inlets-uplink-client
-    spec:
-      replicas: 1
-      selector:
-        matchLabels:
-          app: inlets-uplink-client
-      template:
-        metadata:
-          labels:
-            app: inlets-uplink-client
-        spec:
-          containers:
-          - name: inlets-uplink-client
-            image: ghcr.io/inlets/inlets-pro:0.9.13
-            imagePullPolicy: IfNotPresent
-            command: ["inlets-pro"]
-            args:
-            - "uplink"
-            - "client"
-            - "--url=wss://uplink.example.dev/tunnels/acmeco"
-            - "--upstream=http://gateway.openfaas:8080"
-            - "--token-file=/var/inlets/token"
-            volumeMounts:
-            - mountPath: /var/inlets/
-              name: inlets-token-volume
-              readOnly: true
-          volumes:
-          - name: inlets-token-volume
-            secret:
-              defaultMode: 420
-              secretName: acmeco-token
-    ```
-
 ## Getting help
 
 Feel free to [reach out to our team via email](mailto:support@openfaas.com) for technical support.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
       - Become a provider: /uplink/become-a-provider/
       - Create a tunnel: /uplink/create-tunnels/
       - Manage tunnels: /uplink/manage-tunnels/
+      - Connect to tunnels: /uplink/connect-to-tunnels/
       - Monitoring tunnels: /uplink/monitoring-tunnels/
       - Ingress for tunnels: /uplink/ingress-for-tunnels/
   - Reference:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add a separate page with instuctions for generating connection instuctions for systemd and k8s

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Document the new output formats for the `tunnel connect` command. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Verified the instructions.
- Verified the page is rendered correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

The subheading `Deploy the client in a Kubernetes cluster` has moved from the connect to tunnels page to this new page.

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
