### PR TITLE
The license is base64 encoded twice...

### DIFF
--- a/docs/uplink/create-tunnels.md
+++ b/docs/uplink/create-tunnels.md
@@ -16,7 +16,7 @@ The `inlets` namespace contains the control plane for inlets uplink, so you'll n
 
     ```bash
     export NS="n1"
-    export LICENSE=$(kubectl get secret -n inlets inlets-uplink-license -o jsonpath='{.data.license}')
+    export LICENSE=$(kubectl get secret -n inlets inlets-uplink-license -o jsonpath='{.data.license}' | base64 -d)
 
     kubectl create secret generic \
       -n $NS \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The $LICENSE is base64 encoded when you run the command as is.

But `--from-literal` base64 encodes the license again, so you get the following error from your tunnel POD: 
```
License format may be invalid for inlets-uplink
```

Adding `base64 -d` to the `kubectl get secret` command solved this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
You'll get an error when trying to follow the documentation.
<!--- If it fixes an open issue, please link to the issue here. -->
- [ X ] I have raised an issue to propose this change ([issue](https://github.com/inlets/docs.inlets.dev/issues/22))

## How Has This Been Tested?
I was able to get a tunnel created by implementing this tweak.
### My Environment
Google GKE Cluster Version: 1.26.1-gke.1500
* `inlets-uplink version`
  * Chart: inlets-uplink-provider-0.2.7
  * App Version: 1.0

* Are you using inlets?
  * Yes

* Operating System and version (e.g. Linux, Windows, MacOS):
  * Client OS is Ubuntu 20.04 Server
  * K8s OS is Google COS (Container Optimized Linux)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [ X ] My change requires a change to the documentation.
- [ X ] I have updated the documentation accordingly.
- [ X ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ X ] I have signed-off my commits with `git commit -s`
