### PR TITLE
Document inlets-uplink upstream domains

### DIFF
--- a/docs/uplink/create-tunnels.md
+++ b/docs/uplink/create-tunnels.md
@@ -234,15 +234,41 @@ Content-Length: 973
 
 The following example shows how to access more than one HTTP service over the same tunnel. It is possible to expose multiple upstream services over a single tunnel.
 
+You can add upstreamDomains to the Tunnel resource. Uplink wil create additional Services for each domain so the HTTP data plane is available on different domains. 
+```diff
+apiVersion: uplink.inlets.dev/v1alpha1
+kind: Tunnel
+metadata:
+  name: acmeco
+  namespace: tunnels
+spec:
+  licenseRef:
+    name: inlets-uplink-license
+    namespace: tunnels
+  tcpPorts:
+  - 8080
++  upstreamDomains:
++  - gateway
++  - prometheus
+```
+
+Upstreams can also be added while creating a tunnel with with cli:
+
+```bash
+inlets-pro tunnel create acmeco \
+  --namespace tunnels \
+  --upstream gateway \
+  --upstream prometheus
+```
+
 Start a tunnel client and add multiple upstreams:
 
 ```bash
 inlets-pro uplink client \
   --url wss://uplink.example.com/tunnels/acmeco \
-  --upstream prometheus=http://127.0.0.1:9090 \
-  --upstream gateway=http://127.0.0.1:8080 \
+  --upstream prometheus.tunnels=http://127.0.0.1:9090 \
+  --upstream gateway.tunnels=http://127.0.0.1:8080 \
   --token-file ./token.txt
-
 ```
 
 Access both services using `curl`:
@@ -251,7 +277,7 @@ Access both services using `curl`:
 $ kubectl run -t -i curl --rm \
   --image ghcr.io/openfaas/curl:latest /bin/sh   
 
-$ curl -i -H "Host: prometheus" acmeco.tunnels:8000
+$ curl -i gateway.tunnels:8000
 HTTP/1.1 302 Found
 Content-Length: 29
 Content-Type: text/html; charset=utf-8
@@ -261,7 +287,7 @@ Location: /graph
 <a href="/graph">Found</a>.
 
 
-$ curl -i -H "Host: gateway" acmeco.tunnels:8000
+$ curl -i -H prometheus.tunnels:8000
 HTTP/1.1 301 Moved Permanently
 Content-Length: 39
 Content-Type: text/html; charset=utf-8


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add documentation on how to  expose multiple HTTP services through a single tunnel and invoke them without having to set the Host header in each request by setting multiple .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `upstreamDomain` field has been part of the uplink tunnesl spec for some time now but was still undocumented. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The commands used have been tested on an uplink cluster.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
