### PR TITLE
Remove letsencrypt email flag from documentation

### DIFF
--- a/docs/reference/inletsctl.md
+++ b/docs/reference/inletsctl.md
@@ -54,7 +54,6 @@ inletsctl create \
   --region="lon1" \
   --access-token-file $HOME/do-access-token \
   --letsencrypt-domain $DOMAIN \
-  --letsencrypt-email webmaster@$DOMAIN \
   --letsencrypt-issuer prod
 ```
 

--- a/docs/tutorial/automated-http-server.md
+++ b/docs/tutorial/automated-http-server.md
@@ -36,8 +36,7 @@ inletsctl create \
  --region lon1 \
  --provider digitalocean \
  --access-token-file ~/digital-ocean-api-key.txt \
- --letsencrypt-domain blog.example.com \
- --letsencrypt-email webmaster@example.com
+ --letsencrypt-domain blog.example.com
 ```
 
 A VM will be created in your account using the cheapest plan available, for DigitalOcean this costs 5 USD / mo at time of writing.
@@ -73,8 +72,7 @@ What if I have multiple sites?
 You can pass a number of sub-domains, for instance:
 
 ```bash
- --letsencrypt-domain blog.example.com,grafana.example.com \
- --letsencrypt-email webmaster@example.com
+ --letsencrypt-domain blog.example.com,grafana.example.com
 ```
 
 ## Connect your tunnel client

--- a/docs/tutorial/manual-http-server.md
+++ b/docs/tutorial/manual-http-server.md
@@ -33,8 +33,7 @@ export DOMAIN="example.com"
   --auto-tls-san 192.168.0.10 \
   --letsencrypt-domain subdomain1.$DOMAIN \
   --letsencrypt-domain subdomain2.$DOMAIN \
-  --letsencrypt-email contact@$DOMAIN \
-  --letsencrypt-issuer staging
+  --letsencrypt-issuer staging \
   --token $TOKEN
 ```
 


### PR DESCRIPTION
## Description
Update documentation to remove `--letsencrypt-email` flag from examples, reflecting its removal from the inelts CLIs.

## Motivation and Context
- [ ] I have raised an issue to propose this change ([required](https://github.com/inlets/docs.inlets.dev/blob/master/CONTRIBUTING.md))

The `--letsencrypt-email` flag has been removed from inlets CLIs and documentation needs to be updated accordingly.

## How Has This Been Tested?

Documentation changes reviewed for consistency across all affected files.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`