### PR TITLE
Migrate Inlets Uplink ingress from NGINX to Traefik

### DIFF
--- a/docs/uplink/troubleshooting.md
+++ b/docs/uplink/troubleshooting.md
@@ -1,6 +1,5 @@
 # Troubleshooting
 
-
 ## Client connections
 
 Depending on how you are running the client, with Kubernetes or as a systemd service, use the following commands to check the logs.
@@ -145,7 +144,7 @@ When using TCP tunnels, Proxy Protocol can be a common source of connectivity is
 
 Check if your tunneled service supports Proxy Protocol and verify the configuration at each network hop:
 
-- Load balancers (AWS ALB, nginx, HAProxy)
+- Load balancers (AWS ALB, Traefik, HAProxy)
 - Ingress controllers
 - Service meshes (Istio, Linkerd)
 - The tunneled application itself


### PR DESCRIPTION
## Description

Update installation and expose-tunnels docs for the migration from NGINX Ingress to Traefik.

- Add NGINX Ingress Controller retirement notice
- Change default ingress class to traefik in example values
- Add Traefik rate limiting section with RateLimit and InFlightReq middleware examples
- Add Ingress NGINX section with legacy configuration for users not yet migrated
- Add upgrade notice about ingress class change in chart version 0.5.0

## Motivation and Context

The NGINX Ingress Controller is being retired. The docs need to be updated to reflect Traefik as the default and recommended ingress controller for Inlets Uplink.

- [ ] I have raised an issue to propose this change ([required](https://github.com/inlets/docs.inlets.dev/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

Updated commands and instructions have been validated on an Inlets Uplink cluster.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`